### PR TITLE
fix: should generate correct source map

### DIFF
--- a/packages/swc/src/lib.rs
+++ b/packages/swc/src/lib.rs
@@ -1,6 +1,8 @@
 mod config;
 mod core;
 
+use std::time;
+
 use crate::{
     config::Config,
     core::{mode::Mode, resolve_env::resolve_env, transform::TransformImportMetaEnv},
@@ -35,15 +37,22 @@ pub fn process_transform(program: Program, metadata: TransformPluginProgramMetad
                 != "production"
         }
     };
+
+    let now = time::SystemTime::now()
+        .duration_since(time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis();
     if should_inline_env {
-        program.fold_with(&mut as_folder(TransformImportMetaEnv {
-            mode: Mode::Inline {
+        program.fold_with(&mut as_folder(TransformImportMetaEnv::new(
+            Mode::Inline {
                 env: resolve_env(config.env_path, config.env_example_path),
             },
-        }))
+            now,
+        )))
     } else {
-        program.fold_with(&mut as_folder(TransformImportMetaEnv {
-            mode: Mode::Placeholder,
-        }))
+        program.fold_with(&mut as_folder(TransformImportMetaEnv::new(
+            Mode::Placeholder,
+            now,
+        )))
     }
 }


### PR DESCRIPTION
fix: #9 

- Use `globalThis` to access environment variables instead of replacing placeholders to avoid affecting the source map of the source code.
- ~~Generate code for the virtual module.~~ Replace specific templates with environment variable definitions.
- ~~Generated modules should contain hashes to invalidate caches. (make each bundle unique)~~ Since `index.html` is generally set to no-cache, we can put specific templates in index.html to avoid caching environment variables.
- ~~To be able to disable caching for the generated module, the name of the generated module should contain a unique name prefix. (same as disabling caching for `index.html`)~~
