### PR TITLE
fix(cli): cli should escape double quotes of values

### DIFF
--- a/packages/cli/src/__tests__/replace-all-placeholder-with-env.test.ts
+++ b/packages/cli/src/__tests__/replace-all-placeholder-with-env.test.ts
@@ -62,8 +62,8 @@ describe("replaceAllPlaceholderWithEnv", () => {
     // arrange
     const code = `JSON.parse('"import_meta_env_placeholder"')`;
     const env = {
-      KEY1: "{\"child1\":\"value1\"}",
-      KEY2: "{\"child2\":\"value2\"}",
+      KEY1: '{"child1":"value1"}',
+      KEY2: '{"child2":"value2"}',
     };
 
     // act

--- a/packages/cli/src/__tests__/replace-all-placeholder-with-env.test.ts
+++ b/packages/cli/src/__tests__/replace-all-placeholder-with-env.test.ts
@@ -57,4 +57,21 @@ describe("replaceAllPlaceholderWithEnv", () => {
       `"JSON.parse(\\'{\\\\"EXISTS1\\\\":\\\\"value1\\\\",\\\\"EXISTS2\\\\":\\\\"value2\\\\"}\\')"`,
     );
   });
+
+  test("scriptPlaceholder (4)", () => {
+    // arrange
+    const code = `JSON.parse('"import_meta_env_placeholder"')`;
+    const env = {
+      KEY1: "{\"child1\":\"value1\"}",
+      KEY2: "{\"child2\":\"value2\"}",
+    };
+
+    // act
+    const result = replaceAllPlaceholderWithEnv({ code, env });
+
+    // assert
+    expect(result).toMatchInlineSnapshot(
+      `"JSON.parse('{"KEY1":"{\\\\\\"child1\\\\\\":\\\\\\"value1\\\\\\"}","KEY2":"{\\\\\\"child2\\\\\\":\\\\\\"value2\\\\\\"}"}')"`,
+    );
+  });
 });

--- a/packages/cli/src/replace-all-placeholder-with-env.ts
+++ b/packages/cli/src/replace-all-placeholder-with-env.ts
@@ -10,7 +10,7 @@ export const replaceAllPlaceholderWithEnv = ({
 }): string => {
   const escapedEnv: Record<string, string> = {};
   for (const key of Object.keys(env)) {
-    escapedEnv[key] = env[key].replace(/"/g, '\\"')
+    escapedEnv[key] = env[key].replace(/"/g, '\\"');
   }
   return code
     .replace(

--- a/packages/cli/src/replace-all-placeholder-with-env.ts
+++ b/packages/cli/src/replace-all-placeholder-with-env.ts
@@ -8,26 +8,30 @@ export const replaceAllPlaceholderWithEnv = ({
   code: string;
   env: Record<string, string>;
 }): string => {
+  const escapedEnv: Record<string, string> = {};
+  for (const key of Object.keys(env)) {
+    escapedEnv[key] = env[key].replace(/"/g, '\\"')
+  }
   return code
     .replace(
       createScriptPlaceholderRegExp({
         doubleQuoteSlashCount: 2,
         singleQuoteSlashCount: 1,
       }),
-      `JSON.parse(\\'${serialize(env).replace(/"/g, '\\\\"')}\\')`,
+      `JSON.parse(\\'${serialize(escapedEnv).replace(/"/g, '\\\\"')}\\')`,
     )
     .replace(
       createScriptPlaceholderRegExp({
         doubleQuoteSlashCount: 1,
         singleQuoteSlashCount: 0,
       }),
-      `JSON.parse('${serialize(env).replace(/"/g, '\\"')}')`,
+      `JSON.parse('${serialize(escapedEnv).replace(/"/g, '\\"')}')`,
     )
     .replace(
       createScriptPlaceholderRegExp({
         doubleQuoteSlashCount: 0,
         singleQuoteSlashCount: 0,
       }),
-      `JSON.parse('${serialize(env)}')`,
+      `JSON.parse('${serialize(escapedEnv)}')`,
     );
 };

--- a/packages/examples/babel-starter-example/.env.example.public
+++ b/packages/examples/babel-starter-example/.env.example.public
@@ -1,1 +1,2 @@
 HELLO=
+JSON=

--- a/packages/examples/babel-starter-example/package.json
+++ b/packages/examples/babel-starter-example/package.json
@@ -3,7 +3,7 @@
   "name": "babel-starter-example",
   "scripts": {
     "_test": "node test.js",
-    "dev": "rimraf dist && cross-env HELLO=import-meta-env SECRET1=secret1 SECRET2=secret2 ./node_modules/.bin/babel src --out-dir dist"
+    "dev": "rimraf dist && cross-env HELLO=import-meta-env JSON={\\\"KEY\\\":\\\"import-meta-env\\\"} ./node_modules/.bin/babel src --out-dir dist"
   },
   "devDependencies": {
     "@babel/cli": "^7.17.6",

--- a/packages/examples/babel-starter-example/src/index.js
+++ b/packages/examples/babel-starter-example/src/index.js
@@ -1,1 +1,2 @@
 console.log(`Hello: ${import.meta.env.HELLO}`);
+console.log(`JSON: ${JSON.stringify(JSON.parse(import.meta.env.JSON))}`);

--- a/packages/examples/babel-starter-example/test.dev.js
+++ b/packages/examples/babel-starter-example/test.dev.js
@@ -13,7 +13,7 @@ module.exports = () => {
 
   // act
   childProcess.execSync(
-    `npx cross-env HELLO=${hello} ./node_modules/.bin/babel src --out-dir dist`,
+    `npx cross-env HELLO=${hello} JSON={\\\"hello\\\":\\\"${hello}\\\"} ./node_modules/.bin/babel src --out-dir dist`,
     {
       stdio: "inherit",
     },
@@ -21,5 +21,5 @@ module.exports = () => {
   const output = childProcess.execSync("node dist/index.js").toString().trim();
 
   // assert
-  expect(output).to.equal(`Hello: ${hello}`);
+  expect(output).to.equal(`Hello: ${hello}\nJSON: {"hello":"${hello}"}`);
 };

--- a/packages/examples/rollup-swc-example/.env.example.public
+++ b/packages/examples/rollup-swc-example/.env.example.public
@@ -1,1 +1,2 @@
 HELLO=
+JSON=

--- a/packages/examples/rollup-swc-example/package.json
+++ b/packages/examples/rollup-swc-example/package.json
@@ -5,11 +5,11 @@
     "_test": "node test.js",
     "dev:watch": "rollup -c -w",
     "dev:start": "node ../serve.js -d public -p 3000",
-    "dev": "rimraf bundle && echo HELLO=import-meta-env > .env && concurrently npm:dev:*",
+    "dev": "rimraf bundle && echo HELLO=import-meta-env\\\\\\nJSON={\\\"hello\\\":\\\"import-meta-env\\\"} > .env && concurrently npm:dev:*",
     "build": "rimraf dist && npm run build:pre && npm run build:post",
     "build:pre": "cross-env NODE_ENV=production rollup -c",
     "build:post": "cp public/index.html dist/index.html",
-    "preview": "echo HELLO=import-meta-env > .env && import-meta-env -x .env.example.public && node ../serve.js -d dist -p 4173"
+    "preview": "echo HELLO=import-meta-env\\\\\\nJSON={\\\"hello\\\":\\\"import-meta-env\\\"} > .env && import-meta-env -x .env.example.public && node ../serve.js -d dist -p 4173"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^11.2.1",

--- a/packages/examples/rollup-swc-example/src/main.js
+++ b/packages/examples/rollup-swc-example/src/main.js
@@ -1,3 +1,4 @@
 document.querySelector("#app").innerHTML = `
   <h1>Hello: ${import.meta.env.HELLO}</h1>
+  <h1>JSON: ${JSON.stringify(JSON.parse(import.meta.env.JSON))}</h1>
 `;

--- a/packages/examples/rollup-swc-example/test.dev.js
+++ b/packages/examples/rollup-swc-example/test.dev.js
@@ -8,11 +8,11 @@ module.exports = async () => {
   const commands = [
     "npx rimraf dist",
     "npm add ../../swc/import-meta-env-swc-test.tgz",
-    `echo HELLO=${hello} > .env`,
+    `echo HELLO=${hello}\\\\\\nJSON={\\"hello\\":\\"${hello}\\"} > .env`,
     `npx cross-env NODE_ENV=development rollup -c`,
   ];
   const longRunningCommands = [`node ../serve.js -d public -p ${port}`];
-  const expected = `Hello: ${hello}`;
+  const expected = `Hello: ${hello}\nJSON: {"hello":"${hello}"}`;
   const url = `http://localhost:${port}`;
   const waitMs = 2000;
   await runTest({

--- a/packages/examples/rollup-swc-example/test.prod.js
+++ b/packages/examples/rollup-swc-example/test.prod.js
@@ -11,11 +11,11 @@ module.exports = async () => {
     "npm add ../../swc/import-meta-env-swc-test.tgz",
     `npx cross-env NODE_ENV=production rollup -c`,
     "cp public/index.html dist/index.html",
-    `echo HELLO=${hello} > .env`,
+    `echo HELLO=${hello}\\\\\\nJSON={\\"hello\\":\\"${hello}\\"} > .env`,
     `npx cross-env npx import-meta-env -x .env.example.public`,
   ];
   const longRunningCommands = [`node ../serve.js -d dist -p ${port}`];
-  const expected = `Hello: ${hello}`;
+  const expected = `Hello: ${hello}\nJSON: {"hello":"${hello}"}`;
   const url = `http://localhost:${port}`;
   const waitMs = 2000;
   await runTest({

--- a/packages/examples/swc-example/.env.example.public
+++ b/packages/examples/swc-example/.env.example.public
@@ -1,1 +1,2 @@
 HELLO=
+JSON=

--- a/packages/examples/swc-example/package.json
+++ b/packages/examples/swc-example/package.json
@@ -3,7 +3,7 @@
   "name": "swc-example",
   "scripts": {
     "_test": "node test.js",
-    "dev": "echo HELLO=import-meta-env > .env && npx cross-env SWC_ENV=development swc src -d dist -s true"
+    "dev": "echo HELLO=import-meta-env\\\\\\nJSON={\\\"hello\\\":\\\"import-meta-env\\\"} > .env && npx cross-env SWC_ENV=development swc src -d dist -s true"
   },
   "license": "MIT",
   "devDependencies": {

--- a/packages/examples/swc-example/src/index.js
+++ b/packages/examples/swc-example/src/index.js
@@ -1,1 +1,2 @@
 console.log(`Hello: ${import.meta.env.HELLO}`);
+console.log(`JSON: ${JSON.stringify(JSON.parse(import.meta.env.JSON))}`);

--- a/packages/examples/swc-example/test.dev.js
+++ b/packages/examples/swc-example/test.dev.js
@@ -7,9 +7,12 @@ module.exports = () => {
   childProcess.execSync("npx rimraf dist .env", {
     stdio: "inherit",
   });
-  childProcess.execSync(`echo "HELLO=${hello}\nJSON={\\"hello\\\":\\\"${hello}\\\"}" > .env`, {
-    stdio: "inherit",
-  });
+  childProcess.execSync(
+    `echo "HELLO=${hello}\nJSON={\\"hello\\\":\\\"${hello}\\\"}" > .env`,
+    {
+      stdio: "inherit",
+    },
+  );
   childProcess.execSync("npm add ../../swc/import-meta-env-swc-test.tgz", {
     stdio: "inherit",
   });

--- a/packages/examples/swc-example/test.dev.js
+++ b/packages/examples/swc-example/test.dev.js
@@ -7,7 +7,7 @@ module.exports = () => {
   childProcess.execSync("npx rimraf dist .env", {
     stdio: "inherit",
   });
-  childProcess.execSync(`echo "HELLO=${hello}" > .env`, {
+  childProcess.execSync(`echo "HELLO=${hello}\nJSON={\\"hello\\\":\\\"${hello}\\\"}" > .env`, {
     stdio: "inherit",
   });
   childProcess.execSync("npm add ../../swc/import-meta-env-swc-test.tgz", {
@@ -24,5 +24,5 @@ module.exports = () => {
   const output = childProcess.execSync("node dist/index.js").toString().trim();
 
   // assert
-  expect(output).to.equal(`Hello: ${hello}`);
+  expect(output).to.equal(`Hello: ${hello}\nJSON: {"hello":"${hello}"}`);
 };

--- a/packages/examples/webpack-starter-example/.env.example.public
+++ b/packages/examples/webpack-starter-example/.env.example.public
@@ -1,1 +1,2 @@
 HELLO=
+JSON=

--- a/packages/examples/webpack-starter-example/package.json
+++ b/packages/examples/webpack-starter-example/package.json
@@ -5,9 +5,9 @@
     "_test": "node test.js",
     "dev:watch": "webpack --watch",
     "dev:start": "node ../serve.js -d dist -p 3000",
-    "dev": "rimraf bundle && cross-env HELLO=import-meta-env NODE_ENV=development concurrently npm:dev:*",
+    "dev": "rimraf bundle && cross-env HELLO=import-meta-env JSON={\\\"hello\\\":\\\"import-meta-env\\\"} NODE_ENV=development concurrently npm:dev:*",
     "build": "rimraf dist && cross-env NODE_ENV=production webpack",
-    "preview": "cross-env HELLO=import-meta-env import-meta-env -x .env.example.public && node ../serve.js -d dist -p 4173"
+    "preview": "cross-env HELLO=import-meta-env JSON={\\\"hello\\\":\\\"import-meta-env\\\"} import-meta-env -x .env.example.public && node ../serve.js -d dist -p 4173"
   },
   "devDependencies": {
     "concurrently": "7.0.0",

--- a/packages/examples/webpack-starter-example/src/index.js
+++ b/packages/examples/webpack-starter-example/src/index.js
@@ -1,3 +1,4 @@
 document.querySelector("body").innerHTML = `
   <h1>Hello: ${import.meta.env.HELLO}</h1>
+  <h1>JSON: ${JSON.stringify(JSON.parse(import.meta.env.JSON))}</h1>
 `;

--- a/packages/examples/webpack-starter-example/test.dev.js
+++ b/packages/examples/webpack-starter-example/test.dev.js
@@ -8,10 +8,10 @@ module.exports = async () => {
   const commands = [
     "npx rimraf dist node_modules/.cache",
     "npm add ../../unplugin/import-meta-env-unplugin-test.tgz",
-    `npx cross-env NODE_ENV=development HELLO=${hello} webpack`,
+    `npx cross-env NODE_ENV=development HELLO=${hello} JSON={\\\"hello\\\":\\\"${hello}\\\"} webpack`,
   ];
   const longRunningCommands = [`node ../serve.js -d dist -p ${port}`];
-  const expected = `Hello: ${hello}`;
+  const expected = `Hello: ${hello}\nJSON: {"hello":"${hello}"}`;
   const url = `http://localhost:${port}`;
   const waitMs = 2000;
   await runTest({

--- a/packages/examples/webpack-starter-example/test.prod.js
+++ b/packages/examples/webpack-starter-example/test.prod.js
@@ -10,10 +10,10 @@ module.exports = async () => {
     "npm add ../../cli/import-meta-env-cli-test.tgz",
     "npm add ../../unplugin/import-meta-env-unplugin-test.tgz",
     "npx cross-env NODE_ENV=production webpack",
-    `npx cross-env HELLO=${hello} npx import-meta-env -x .env.example.public`,
+    `npx cross-env HELLO=${hello} JSON={\\\"hello\\\":\\\"${hello}\\\"} npx import-meta-env -x .env.example.public`,
   ];
   const longRunningCommands = [`node ../serve.js -d dist -p ${port}`];
-  const expected = `Hello: ${hello}`;
+  const expected = `Hello: ${hello}\nJSON: {"hello":"${hello}"}`;
   const url = `http://localhost:${port}`;
   const waitMs = 2000;
   await runTest({


### PR DESCRIPTION
There is an inconsistent behavior between the CLI (runtime transform) and other tools (compile-time transform):

We have to escape it in `.env` file before this PR:

```ini
# .env
JSON={\"foo\": \"bar\"}
```

But in compile-time transform, we can do this (without escape):

```ini
# .env
JSON={"foo": "bar"}
```

The latter should works in runtime transform too!
